### PR TITLE
Support helm 3.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,8 +110,10 @@ jobs:
       DOCKER_NAMESPACE: fybrik-system
       DOCKER_USERNAME: ${{ github.actor }}
       DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      DOCKER_PUBLIC_TAGNAME: latest
+      HELM_PUBLIC_TAGNAME: 0.0.0
     needs: [verify, test, integration-tests]
-    if: ${{ github.event_name != 'pull_request' && github.repository == 'fybrik/data-movement-operator' }}
+    if: ${{ github.event_name != 'pull_request' }}
     steps:
     - uses: actions/checkout@v2
     - name: Download artifact
@@ -125,28 +127,13 @@ jobs:
     - run: docker images
     - id: version
       name: Infer version
+      if: ${{ (github.event_name != 'pull_request') && contains(github.ref, 'tags') }}
       run: |
-        version="${GITHUB_REF#refs/tags/v}"
-        push_tag_event='true'
-        if  [[ $version == refs/* ]] ;
-        then
-            push_tag_event='false'
-            branch="${GITHUB_REF#refs/heads/}"
-            version=$branch
-        fi
-        if [[ $version == releases/* ]] ;
-        then
-           releaseVersion="${GITHUB_REF#refs/heads/releases/}"
-           version="$releaseVersion-rc"
-        fi
-        echo ::set-output name=version::$version
-        echo ::set-output name=push_tag_event::$push_tag_event
-    - name: Publish images
-      env:
-        DOCKER_PUBLIC_TAGNAME:  ${{ steps.version.outputs.version }}
-      run: make docker-retag-and-push-public && make helm-push-public
-    - name: Publish latest image tag on push tag event
-      if: steps.version.outputs.push_tag_event == 'true'
-      env:
-        DOCKER_PUBLIC_TAGNAME: 'latest'
-      run: make docker-retag-and-push-public && make helm-push-public
+        echo "HELM_PUBLIC_TAGNAME=${GITHUB_REF##*/v}" >> $GITHUB_ENV
+        echo "DOCKER_PUBLIC_TAGNAME=${GITHUB_REF##*/v}" >> $GITHUB_ENV
+    - name: Helm chart push
+      if: ${{ (github.event_name != 'pull_request') }}
+      run: |
+        export HELM_EXPERIMENTAL_OCI=1
+        echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login -u "${{ github.actor }}" --password-stdin "ghcr.io"
+        make docker-retag-and-push-public && make helm-push-public

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 include Makefile.env
-export DOCKER_TAGNAME ?= master
+export DOCKER_TAGNAME ?= latest
 export KUBE_NAMESPACE ?= fybrik-system
 export BLUEPRINT_NAMESPACE?=fybrik-blueprints
 
@@ -80,7 +80,7 @@ docker-push:
 
 DOCKER_PUBLIC_HOSTNAME ?= ghcr.io
 DOCKER_PUBLIC_NAMESPACE ?= fybrik
-DOCKER_PUBLIC_TAGNAME ?= master
+DOCKER_PUBLIC_TAGNAME ?= latest
 
 DOCKER_PUBLIC_NAMES := \
 	dmo-manager
@@ -99,7 +99,7 @@ docker-retag-and-push-public:
 
 .PHONY: helm-push-public
 helm-push-public:
-	DOCKER_HOSTNAME=${DOCKER_PUBLIC_HOSTNAME} DOCKER_NAMESPACE=${DOCKER_PUBLIC_NAMESPACE} DOCKER_TAGNAME=${DOCKER_PUBLIC_TAGNAME} make -C modules helm-chart-push
+	DOCKER_HOSTNAME=${DOCKER_PUBLIC_HOSTNAME} DOCKER_NAMESPACE=${DOCKER_PUBLIC_NAMESPACE} HELM_TAGNAME=${HELM_PUBLIC_TAGNAME} make -C modules helm-chart-push
 
 .PHONY: save-images
 save-images:

--- a/charts/data-movement-operator/integration-tests.values.yaml
+++ b/charts/data-movement-operator/integration-tests.values.yaml
@@ -5,7 +5,7 @@
 # Global configuration applies to multiple components installed by this chart
 global:
   hub: localhost:5000/fybrik-system
-  tag: "master"
+  tag: "latest"
   imagePullPolicy: "Always"
 
 # Manager component

--- a/hack/make-rules/helm.mk
+++ b/hack/make-rules/helm.mk
@@ -1,9 +1,12 @@
 HELM_VALUES ?= \
 	--set hello=world1
 
+HELM_TAGNAME ?= '0.0.0'
 CHART := ${DOCKER_NAME}
 HELM_RELEASE ?= rel1-${DOCKER_NAME}
+CHART_SCHEME ?= oci
 TEMP := /tmp
+CHART_PATH ?= ${CHART_SCHEME}://${DOCKER_HOSTNAME}/${DOCKER_NAMESPACE}/
 
 export HELM_EXPERIMENTAL_OCI=1
 export GODEBUG=x509ignoreCN=0
@@ -29,15 +32,13 @@ helm-install: $(TOOLBIN)/helm
 
 .PHONY: helm-chart-push
 helm-chart-push: helm-login $(TOOLBIN)/helm
-	$(ABSTOOLBIN)/helm chart save ../${CHART} ${IMG}
-	$(ABSTOOLBIN)/helm chart list ../${CHART}
-	$(ABSTOOLBIN)/helm chart push ${IMG}
-	$(ABSTOOLBIN)/helm chart remove ${IMG}
+	$(ABSTOOLBIN)/helm package ../${CHART} --version=${HELM_TAGNAME} --destination=${TEMP}
+	$(ABSTOOLBIN)/helm push ${TEMP}/${CHART}-${HELM_TAGNAME}.tgz ${CHART_PATH}
+	rm -rf ${TEMP}/${CHART}-${HELM_TAGNAME}.tgz
 
 .PHONY: helm-chart-pull
 helm-chart-pull: helm-login $(TOOLBIN)/helm
-	$(ABSTOOLBIN)/helm chart pull ${IMG} 
-	$(ABSTOOLBIN)/helm chart list
+	$(ABSTOOLBIN)/helm pull ${CHART_PATH}/${CHART} --version ${HELM_TAGNAME}
 
 .PHONY: helm-chart-list
 helm-chart-list: $(TOOLBIN)/helm
@@ -45,8 +46,7 @@ helm-chart-list: $(TOOLBIN)/helm
 
 .PHONY: helm-chart-install
 helm-chart-install: $(TOOLBIN)/helm
-	$(ABSTOOLBIN)/helm chart export --destination=${TEMP} ${IMG} 
-	$(ABSTOOLBIN)/helm install ${HELM_RELEASE} ${TEMP}/${CHART} ${HELM_VALUES}
+	$(ABSTOOLBIN)/helm install ${HELM_RELEASE} ${CHART_PATH}/${CHART} --version ${HELM_TAGNAME} ${HELM_VALUES}
 	$(ABSTOOLBIN)/helm list
 
 .PHONY: helm-template

--- a/hack/tools/install_helm.sh
+++ b/hack/tools/install_helm.sh
@@ -9,10 +9,8 @@ header_text "Checking for bin/helm"
 [[ -f bin/helm ]] && exit 0
 
 header_text "Installing bin/helm"
-# Helm is currently fixed to 3.6.3 until the deployment process is migrated to 3.7.0 (https://github.com/helm/helm/releases/tag/v3.7.0)
-# Some used experimental OCI features have been removed.
 mkdir -p ./bin
 curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
 chmod 700 get_helm.sh
-HELM_INSTALL_DIR=bin DESIRED_VERSION=v3.6.3 ./get_helm.sh --no-sudo
+HELM_INSTALL_DIR=bin DESIRED_VERSION=v3.7.0 ./get_helm.sh --no-sudo
 rm -rf get_helm.sh

--- a/manager/Makefile
+++ b/manager/Makefile
@@ -61,7 +61,7 @@ wait_for_manager: $(TOOLBIN)/kubectl
 .PHONY: run-integration-tests
 run-integration-tests: export DOCKER_HOSTNAME?=localhost:5000
 run-integration-tests: export DOCKER_NAMESPACE?=fybrik-system
-run-integration-tests: export DOCKER_TAGNAME?=master
+run-integration-tests: export DOCKER_TAGNAME?=latest
 run-integration-tests: export USE_MOCKUP_CONNECTOR?=true
 run-integration-tests: wait_for_manager
 	NO_SIMULATED_PROGRESS=true USE_EXISTING_CONTROLLER=true USE_EXISTING_CLUSTER=true go test ./... -v -run TestMotionAPIs -count 1

--- a/modules/fybrik-implicit-copy-batch/values.yaml
+++ b/modules/fybrik-implicit-copy-batch/values.yaml
@@ -12,7 +12,7 @@
 # app_cluster:
 labels: {}
 
-image: "ghcr.io/fybrik/mover:latest"
+image: "ghcr.io/fybrik/mover:master"
 imagePullPolicy: null
 noFinalizer: "true"
 

--- a/modules/fybrik-implicit-copy-stream/values.yaml
+++ b/modules/fybrik-implicit-copy-stream/values.yaml
@@ -5,7 +5,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-image: "ghcr.io/fybrik/mover:latest"
+image: "ghcr.io/fybrik/mover:master"
 imagePullPolicy: null
 noFinalizer: "true"
 

--- a/modules/implicit-copy-batch-module.yaml
+++ b/modules/implicit-copy-batch-module.yaml
@@ -68,7 +68,7 @@ spec:
       - id: removed-ID
         level: 2  # column
   chart:
-    name: ghcr.io/fybrik/fybrik-implicit-copy-batch:0.1.0
+    name: ghcr.io/fybrik/fybrik-implicit-copy-batch:0.0.0-master
   statusIndicators:
     - kind: BatchTransfer
       successCondition: status.status == SUCCEEDED

--- a/modules/implicit-copy-stream-module.yaml
+++ b/modules/implicit-copy-stream-module.yaml
@@ -32,7 +32,7 @@ spec:
       - id: removed-ID
         level: 2  # column
   chart:
-    name: ghcr.io/fybrik/fybrik-implicit-copy-stream:0.1.0
+    name: ghcr.io/fybrik/fybrik-implicit-copy-stream:0.0.0-master
   statusIndicators:
     - kind: StreamTransfer
       successCondition: status.status == SUCCEEDED


### PR DESCRIPTION
Related to https://github.com/fybrik/data-movement-operator/issues/8

NOTE: This PR should not be merged until all the fybrik components will support helm 3.7 as well. As the OCI registry support in helm is experimental there is no backward compatibility promise with prior OCI support.

This PR handles the upgrade to helm 3.7 in particular with respect to the changes done to the OCI registry support as described in https://github.com/helm/community/blob/main/hips/hip-0006.md:
it updates the helm commands in the Makefile and the GitHub actions.

Versions are created as follows: (In helm 3.7 OCI reference tags must be valid SemVer)
    # tags starting with v will be released as what comes after `v`. (e.g. refs/tags/v1.0 -> 1.0)
    # release branches in e.g. (refs/heads/releases/1.0 -> 1.0-rc i) This applies to both docker images tags and helm chart tags
    # other branches (e.g. master) will be released with branch name as a version for the docker images. For the helm chart OCI reference tag  0.0.0-<branch-name> will be used.


