### PR TITLE
Update implicit-copy-stream and implicit-copy-batch charts

### DIFF
--- a/modules/fybrik-implicit-copy-batch/templates/batchtransfer.yaml
+++ b/modules/fybrik-implicit-copy-batch/templates/batchtransfer.yaml
@@ -56,23 +56,37 @@ spec:
 {{ toYaml .Values.copy.destination.vault.write | indent 8 }}
       {{ end }}
     {{ end }}
-  {{ if .Values.copy.transformations }}
+  {{- if .Values.copy.transformations }}
   transformation:
-  {{ range .Values.copy.transformations }}
-  {{ if eq .id "redact-ID" }}
-  - action: "RedactColumns"
-    name: "redacting column: {{ .args.column_name }}"
-    columns: [ {{ .args.column_name | quote }} ]
-    options:
-      redactValue: "XXXXXX"
-  {{ end }}
-  {{ if eq .id "removed-ID" }}
-  - action: "RemoveColumns"
-    name: "redacting column: {{ .args.column_name }}"
-    columns: [ "{{ .args.column_name }}" ]
-  {{ end }}
-  {{ end }}
-  {{ end }}
+  {{- $redactColumns := list -}}
+  {{- $removeColumns := list -}}
+  {{- range .Values.copy.transformations -}}
+    {{- if eq .name "RedactAction" -}}
+      {{- $redactColumns = .RedactAction.columns -}}
+    {{- end -}}
+    {{- if eq .name "RemoveAction" -}}
+      {{- $removeColumns = .RemoveAction.columns -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if $redactColumns }}
+    - action: "RedactColumns"
+      name: "redacting columns: {{ $redactColumns }}"
+      columns:
+        {{- range $redactColumns}}
+        - {{ . }}
+        {{- end }}
+      options:
+        redactValue: "XXXXX"
+  {{- end }}
+  {{- if $removeColumns }}
+    - action: "RemoveColumns"
+      name: "removing columns: {{ $removeColumns }}"
+      columns:
+        {{- range $removeColumns}}
+        - {{ . }}
+        {{- end }}
+  {{- end }}
+  {{- end }}
   {{ if .Values.image }}
   image: {{ .Values.image | quote }}
   {{ end }}

--- a/modules/fybrik-implicit-copy-batch/values.yaml.sample
+++ b/modules/fybrik-implicit-copy-batch/values.yaml.sample
@@ -37,11 +37,13 @@ copy:
         secretPath: "/v1/kubernetes-secrets/secret-name?namespace=default"
 
   transformations:
-  - id: "redact-ID"
-    level: 2 # column
-    args:
-      column_name: col1
-  - id: "removed-ID"
-    level: 2 # column
-    args:
-      column_name: col2
+  - RedactAction:
+      columns:
+      - col1
+      - col2
+    name: RedactAction
+  - RemoveAction:
+      columns:
+      - col1
+      - col2
+    name: RemoveAction

--- a/modules/fybrik-implicit-copy-stream/templates/streamtransfer.yaml
+++ b/modules/fybrik-implicit-copy-stream/templates/streamtransfer.yaml
@@ -36,23 +36,37 @@ spec:
       vault:
 {{ toYaml .Values.copy.destination.vault.write | indent 8 }}
       {{ end }}
-  {{ if .Values.copy.transformations }}
+  {{- if .Values.copy.transformations }}
   transformation:
-  {{ range .Values.copy.transformations }}
-  {{ if eq .id "redact-ID" }}
-  - action: "RedactColumns"
-    name: "redacting column: {{ .args.column_name }}"
-    columns: [ {{ .args.column_name | quote }} ]
-    options:
-      redactValue: "XXXXXX"
-  {{ end }}
-  {{ if eq .id "removed-ID" }}
-  - action: "RemoveColumns"
-    name: "redacting column: {{ .args.column_name }}"
-    columns: [ "{{ .args.column_name }}" ]
-  {{ end }}
-  {{ end }}
-  {{ end }}
+  {{- $redactColumns := list -}}
+  {{- $removeColumns := list -}}
+  {{- range .Values.copy.transformations -}}
+    {{- if eq .name "RedactAction" -}}
+      {{- $redactColumns = .RedactAction.columns -}}
+    {{- end -}}
+    {{- if eq .name "RemoveAction" -}}
+      {{- $removeColumns = .RemoveAction.columns -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if $redactColumns }}
+    - action: "RedactColumns"
+      name: "redacting columns: {{ $redactColumns }}"
+      columns:
+        {{- range $redactColumns}}
+        - {{ . }}
+        {{- end }}
+      options:
+        redactValue: "XXXXX"
+  {{- end }}
+  {{- if $removeColumns }}
+    - action: "RemoveColumns"
+      name: "removing columns: {{ $removeColumns }}"
+      columns:
+        {{- range $removeColumns}}
+        - {{ . }}
+        {{- end }}
+  {{- end }}
+  {{- end }}
   triggerInterval: "10 seconds"
   {{ if .Values.image }}
   image: {{ .Values.image | quote }}

--- a/modules/fybrik-implicit-copy-stream/values.yaml.sample
+++ b/modules/fybrik-implicit-copy-stream/values.yaml.sample
@@ -35,13 +35,13 @@ copy:
         secretPath: "/v1/kubernetes-secrets/secret-name?namespace=default"
 
   transformations:
-  - args:
-      column: SSN
-    id: redact-ID
-    level: 2
-    name: redact
-  - args:
-      column: BLOOD_TYPE
-    id: encrypt-ID
-    level: 2
-    name: encrypt
+  - RedactAction:
+      columns:
+      - col1
+      - col2
+    name: RedactAction
+  - RemoveAction:
+      columns:
+      - col1
+      - col2
+    name: RemoveAction

--- a/modules/implicit-copy-batch-module.yaml
+++ b/modules/implicit-copy-batch-module.yaml
@@ -63,10 +63,8 @@ spec:
           protocol: s3
           dataformat: orc
       actions:
-      - id: redact-ID
-        level: 2  # column
-      - id: removed-ID
-        level: 2  # column
+        - name: RedactAction
+        - name: RemoveAction
   chart:
     name: ghcr.io/fybrik/fybrik-implicit-copy-batch:0.1.0
   statusIndicators:

--- a/modules/implicit-copy-stream-module.yaml
+++ b/modules/implicit-copy-stream-module.yaml
@@ -27,10 +27,8 @@ spec:
           protocol: s3
           dataformat: parquet
       actions:
-      - id: redact-ID
-        level: 2  # column
-      - id: removed-ID
-        level: 2  # column
+        - name: RedactAction
+        - name: RemoveAction
   chart:
     name: ghcr.io/fybrik/fybrik-implicit-copy-stream:0.1.0
   statusIndicators:


### PR DESCRIPTION
Address issue #10 :

When testing implicit-copy-batch-module.yaml and implicit-copy-stream-module.yaml against fybrik 0.5.0 the actions are wrong.

Current actions are:

actions:
- id: redact-ID
level: 2 # column
- id: removed-ID
level: 2 # column

and should be:

actions:
- name: RedactAction
- name: RemoveAction

This PR fixes that and also fybrik-implicit-copy-batch and fybrik-implicit-copy-stream charts.

