### PR TITLE
Fix usage of mover image name to dmo-manager image name

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -11,5 +11,5 @@ ${TOOLBIN}/yq eval --inplace ".appVersion = \"$RELEASE\"" ./charts/data-movement
 ${TOOLBIN}/yq eval --inplace ".version = \"$RELEASE\"" ./modules/fybrik-implicit-copy-batch/Chart.yaml
 ${TOOLBIN}/yq eval --inplace ".version = \"$RELEASE\"" ./modules/fybrik-implicit-copy-stream/Chart.yaml
 
-${TOOLBIN}/yq eval --inplace ".image = \"ghcr.io/fybrik/mover:$RELEASE\"" modules/fybrik-implicit-copy-batch/values.yaml
-${TOOLBIN}/yq eval --inplace ".image = \"ghcr.io/fybrik/mover:$RELEASE\"" modules/fybrik-implicit-copy-stream/values.yaml
+${TOOLBIN}/yq eval --inplace ".image = \"ghcr.io/fybrik/dmo-manager:$RELEASE\"" modules/fybrik-implicit-copy-batch/values.yaml
+${TOOLBIN}/yq eval --inplace ".image = \"ghcr.io/fybrik/dmo-manager:$RELEASE\"" modules/fybrik-implicit-copy-stream/values.yaml

--- a/manager/apis/motion/v1alpha1/batchtransfer_types.go
+++ b/manager/apis/motion/v1alpha1/batchtransfer_types.go
@@ -521,9 +521,9 @@ type BatchTransferList struct {
 const (
 	BatchtransferFinalizer       = "batchtransfer.finalizers.ibm.com"
 	BatchtransferFinalizerBinary = "/finalizer"
-	BatchtransferBinary          = "/mover"
+	BatchtransferBinary          = "/dmo-manager"
 	ConfigSecretVolumeName       = "conf-secret"
-	ConfigSecretMountPath        = "/etc/mover"
+	ConfigSecretMountPath        = "/etc/dmo-manager"
 )
 
 // register above definition...

--- a/manager/apis/motion/v1alpha1/batchtransfer_webhook.go
+++ b/manager/apis/motion/v1alpha1/batchtransfer_webhook.go
@@ -43,7 +43,7 @@ func (r *BatchTransfer) Default() {
 	log.Printf("Defaulting batchtransfer %s", r.Name)
 	if r.Spec.Image == "" {
 		// TODO check if can be removed after upgrading controller-gen to 0.5.0
-		r.Spec.Image = "ghcr.io/fybrik/mover:latest"
+		r.Spec.Image = "ghcr.io/fybrik/dmo-manager:latest"
 	}
 
 	if r.Spec.ImagePullPolicy == "" {

--- a/manager/apis/motion/v1alpha1/batchtransfer_webhook_test.go
+++ b/manager/apis/motion/v1alpha1/batchtransfer_webhook_test.go
@@ -264,7 +264,7 @@ func TestDefaultingS3Bucket(t *testing.T) {
 	batchTransfer.Default()
 
 	assert.Equal(t, corev1.PullIfNotPresent, batchTransfer.Spec.ImagePullPolicy)
-	assert.Equal(t, "ghcr.io/fybrik/mover:latest", batchTransfer.Spec.Image)
+	assert.Equal(t, "ghcr.io/fybrik/dmo-manager:latest", batchTransfer.Spec.Image)
 	assert.Equal(t, "mysecrets:123", batchTransfer.Spec.SecretProviderURL)
 	assert.Equal(t, "demo", batchTransfer.Spec.SecretProviderRole)
 	assert.Equal(t, false, batchTransfer.Spec.Suspend)

--- a/modules/fybrik-implicit-copy-batch/values.yaml
+++ b/modules/fybrik-implicit-copy-batch/values.yaml
@@ -12,8 +12,8 @@
 # app_cluster:
 labels: {}
 
-image: "ghcr.io/fybrik/mover:latest"
-imagePullPolicy: null
+image: "ghcr.io/fybrik/dmo-manager:master"
+imagePullPolicy: Always
 noFinalizer: "true"
 
 # copies from source

--- a/modules/fybrik-implicit-copy-batch/values.yaml.sample
+++ b/modules/fybrik-implicit-copy-batch/values.yaml.sample
@@ -1,4 +1,4 @@
-image: "localhost:5000/fybrik-system/mover:latest"
+image: "localhost:5000/fybrik-system/dmo-manager:latest"
 imagePullPolicy: "IfNotPresent"
 noFinalizer: "true"
 

--- a/modules/fybrik-implicit-copy-stream/values.yaml
+++ b/modules/fybrik-implicit-copy-stream/values.yaml
@@ -5,8 +5,8 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-image: "ghcr.io/fybrik/mover:latest"
-imagePullPolicy: null
+image: "ghcr.io/fybrik/dmo-manager:master"
+imagePullPolicy: Always
 noFinalizer: "true"
 
 copy:

--- a/test/dummy-mover/Dockerfile.dummy-mover
+++ b/test/dummy-mover/Dockerfile.dummy-mover
@@ -3,11 +3,11 @@ ARG REGISTRY=docker.io/library
 FROM ${REGISTRY}/alpine:latest
 WORKDIR /
 
-RUN echo -e '#!/bin/sh\necho "Running dummy batch mover."' > /mover && \
-  chmod +x /mover && \
-  echo -e '#!/bin/sh\necho "Running dummy stream mover."' > /stream && \
+RUN echo -e '#!/bin/sh\necho "Running dummy batch manager."' > /manager && \
+  chmod +x /manager && \
+  echo -e '#!/bin/sh\necho "Running dummy stream manager."' > /stream && \
   chmod +x /stream && \
   echo -e '#!/bin/sh\necho "Running dummy finalizer."' > /finalizer && \
   chmod +x /finalizer
 
-ENTRYPOINT ["/mover"]
+ENTRYPOINT ["/manager"]


### PR DESCRIPTION
Mover image name was changed to "dmo-manger" instead of "mover".  This PR changes places in the code that use the old name.