### PR TITLE
Fix value file fields with wrong formats

### DIFF
--- a/modules/fybrik-implicit-copy-batch/values.yaml
+++ b/modules/fybrik-implicit-copy-batch/values.yaml
@@ -40,6 +40,6 @@ copy:
 #    vault: {}
 
   transformations: []
-  readDataType: "LogData"
-  writeDataType: "LogData"
-  writeOperation: "Overwrite"
+readDataType: "LogData"
+writeDataType: "LogData"
+writeOperation: "Overwrite"


### PR DESCRIPTION
Signed-off-by: Gang Pu <pugangxa@cn.ibm.com>

These values are under spec rather than under copy.