### PR TITLE
Re-create chart-publish.yaml workflow.

### DIFF
--- a/.github/workflows/chart-publish.yaml
+++ b/.github/workflows/chart-publish.yaml
@@ -1,0 +1,41 @@
+name: Update Charts
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    name: Update Charts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main repository
+        uses: actions/checkout@v2
+        with:
+          path: main
+      - name: Checkout charts repository
+        uses: actions/checkout@v2
+        with:
+          repository: fybrik/charts
+          path: charts-repo
+      - run: |
+          rm -rf charts-repo/charts/data-movement-operator
+          cp -r main/charts/data-movement-operator charts-repo/charts
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.CHARTS_APP_ID }}
+          private_key: ${{ secrets.CHARTS_APP_PRIVATE_KEY }}
+          repository: fybrik/charts
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          path: charts-repo
+          signoff: true
+          token: ${{ steps.generate-token.outputs.token }}
+          title: 'Update charts to new release'
+          commit-message: Update charts
+          committer: GitHub <noreply@github.com>
+          delete-branch: true
+

--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ Version 0.5.0 of the data movement operator (DMO) is available in Fybrik 0.5.x.
 | ---              | ---
 | 0.6.x            | 0.6.x
 
+
+Installing the chart: (available from DMO version 0.6.1 and above)
+```
+helm repo add fybrik-charts https://fybrik.github.io/charts
+helm repo update
+helm install data-movement-operator fybrik-charts/data-movement-operator -n fybrik-system --wait
+```
+
 Install latest development version from GitHub:
 ```
 git clone https://github.com/fybrik/data-movement-operator.git

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,7 +7,6 @@ The process of creating a release is described in this document. Replace `X.Y.Z`
 The `releases/X.Y.Z` branch should be created from a base branch. 
 
 For major and minor releases the base is `master` and for patch releases (fixes) the base is `releases/X.Y.(Z-1)`.
-A new patch release should be created before merging pull-requests as described in the next section.
 
 You can do that [directly from GitHub](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository#creating-a-branch).
 


### PR DESCRIPTION
Closes #36

This PR publishes the charts in fybrik/charts repo.