### PR TITLE
Adapt a new structure of module arguments 

### DIFF
--- a/modules/fybrik-implicit-copy-batch/templates/batchtransfer.yaml
+++ b/modules/fybrik-implicit-copy-batch/templates/batchtransfer.yaml
@@ -14,53 +14,55 @@ metadata:
     {{ $key }}: {{ $val | quote }}
 {{ end }}
 spec:
+{{- if and (.Values.assets) (eq (len .Values.assets) 1) -}}
+{{- with (index .Values.assets 0) }}
   source:
-    {{ if .Values.copy.source.connection.s3 }}
+    {{ if .source.connection.s3 }}
     s3:
-      endpoint: {{ .Values.copy.source.connection.s3.endpoint | quote }}
-      bucket: {{ .Values.copy.source.connection.s3.bucket | quote }}
-      objectKey: {{ .Values.copy.source.connection.s3.object_key | quote }}
-      dataFormat: {{ .Values.copy.source.format | quote }}
-      {{ if .Values.copy.source.vault.read }}
+      endpoint: {{ .source.connection.s3.endpoint | quote }}
+      bucket: {{ .source.connection.s3.bucket | quote }}
+      objectKey: {{ .source.connection.s3.object_key | quote }}
+      dataFormat: {{ .source.format | quote }}
+      {{ if .source.vault.read }}
       vault:
-{{ toYaml .Values.copy.source.vault.read | indent 8 }}
+{{ toYaml .source.vault.read | indent 8 }}
       {{ end }}
     {{ end }}
-    {{ if .Values.copy.source.connection.db2 }}
+    {{ if .source.connection.db2 }}
     database:
-      table: {{ .Values.copy.source.connection.db2.table | quote }}
-      db2URL: "jdbc:db2://{{ .Values.copy.source.connection.db2.url }}:{{ .Values.copy.source.connection.db2.port }}/{{ .Values.copy.source.connection.db2.database }}:sslConnection={{ .Values.copy.source.connection.db2.ssl }};"
-      {{ if .Values.copy.source.vault.read }}
+      table: {{ .source.connection.db2.table | quote }}
+      db2URL: "jdbc:db2://{{ .source.connection.db2.url }}:{{ .source.connection.db2.port }}/{{ .source.connection.db2.database }}:sslConnection={{ .source.connection.db2.ssl }};"
+      {{ if .source.vault.read }}
       vault:
-{{ toYaml .Values.copy.source.vault.read | indent 8 }}
+{{ toYaml .source.vault.read | indent 8 }}
       {{ end }}
     {{ end }}
   destination:
-    {{ if .Values.copy.destination.connection.s3 }}
+    {{ if .destination.connection.s3 }}
     s3:
-      endpoint: {{ .Values.copy.destination.connection.s3.endpoint | quote }}
-      bucket: {{ .Values.copy.destination.connection.s3.bucket | quote }}
-      objectKey: {{ .Values.copy.destination.connection.s3.object_key | quote }}
-      dataFormat: {{ .Values.copy.destination.format | quote }}
-      {{ if .Values.copy.destination.vault.write }}
+      endpoint: {{ .destination.connection.s3.endpoint | quote }}
+      bucket: {{ .destination.connection.s3.bucket | quote }}
+      objectKey: {{ .destination.connection.s3.object_key | quote }}
+      dataFormat: {{ .destination.format | quote }}
+      {{ if .destination.vault.write }}
       vault:
-{{ toYaml .Values.copy.destination.vault.write | indent 8 }}
+{{ toYaml .destination.vault.write | indent 8 }}
       {{ end }}
     {{ end }}
-    {{ if .Values.copy.destination.connection.db2 }}
+    {{ if .destination.connection.db2 }}
     database:
-      table: {{ .Values.copy.destination.connection.db2.table | quote }}
-      db2URL: "jdbc:db2://{{ .Values.copy.destination.connection.db2.url }}:{{ .Values.copy.destination.connection.db2.port }}/{{ .Values.copy.destination.connection.db2.database }}:sslConnection={{ .Values.copy.destination.connection.db2.ssl }};"
-      {{ if .Values.copy.destination.vault.write }}
+      table: {{ .destination.connection.db2.table | quote }}
+      db2URL: "jdbc:db2://{{ .destination.connection.db2.url }}:{{ .destination.connection.db2.port }}/{{ .destination.connection.db2.database }}:sslConnection={{ .destination.connection.db2.ssl }};"
+      {{ if .destination.vault.write }}
       vault:
-{{ toYaml .Values.copy.destination.vault.write | indent 8 }}
+{{ toYaml .destination.vault.write | indent 8 }}
       {{ end }}
     {{ end }}
-  {{- if .Values.copy.transformations }}
+  {{- if .transformations }}
   transformation:
   {{- $redactColumns := list -}}
   {{- $removeColumns := list -}}
-  {{- range .Values.copy.transformations -}}
+  {{- range .transformations -}}
     {{- if eq .name "RedactAction" -}}
       {{- $redactColumns = .RedactAction.columns -}}
     {{- end -}}
@@ -86,6 +88,11 @@ spec:
         - {{ . }}
         {{- end }}
   {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- else }}
+  source:
+  destination:
   {{- end }}
   {{ if .Values.image }}
   image: {{ .Values.image | quote }}

--- a/modules/fybrik-implicit-copy-batch/values.yaml
+++ b/modules/fybrik-implicit-copy-batch/values.yaml
@@ -17,8 +17,8 @@ imagePullPolicy: null
 noFinalizer: "true"
 
 # copies from source
-copy:
-  source:
+assets:
+- source:
     vault: {}
     connection:
       s3: {}

--- a/modules/fybrik-implicit-copy-batch/values.yaml.sample
+++ b/modules/fybrik-implicit-copy-batch/values.yaml.sample
@@ -3,8 +3,8 @@ imagePullPolicy: "IfNotPresent"
 noFinalizer: "true"
 
 
-copy:
-  source:
+assets:
+- source:
     connection:
       name: s3
       s3:

--- a/modules/fybrik-implicit-copy-stream/templates/streamtransfer.yaml
+++ b/modules/fybrik-implicit-copy-stream/templates/streamtransfer.yaml
@@ -6,41 +6,43 @@ kind: StreamTransfer
 metadata:
   name: {{ .Release.Name }}
 spec:
+{{- if and (.Values.assets) (eq (len .Values.assets) 1) -}}
+{{- with (index .Values.assets 0) }}
   source:
     kafka:
-      kafkaBrokers: {{ .Values.copy.source.connection.kafka.bootstrap_servers | quote }}
-      schemaRegistryURL: {{ .Values.copy.source.connection.kafka.schema_registry | quote }}
-      kafkaTopic: {{ .Values.copy.source.connection.kafka.topic_name | quote }}
-      dataFormat: {{ .Values.copy.source.format | quote }}
+      kafkaBrokers: {{ .source.connection.kafka.bootstrap_servers | quote }}
+      schemaRegistryURL: {{ .source.connection.kafka.schema_registry | quote }}
+      kafkaTopic: {{ .source.connection.kafka.topic_name | quote }}
+      dataFormat: {{ .source.format | quote }}
       # user: "demo-consumer" # can be taken from vault
       # password: "" # can be taken from vault
       createSnapshot: false
-      sslTruststore: {{ .Values.copy.source.connection.kafka.ssl_truststore | quote }}
+      sslTruststore: {{ .source.connection.kafka.ssl_truststore | quote }}
       sslTruststoreLocation: /opt/spark/work-dir/ca.p12
-      sslTruststorePassword: {{ .Values.copy.source.connection.kafka.ssl_truststore_password | quote }}
-      securityProtocol: {{ .Values.copy.source.connection.kafka.security_protocol | quote }}
-      saslMechanism: {{ .Values.copy.source.connection.kafka.sasl_mechanism | quote }}
-      keyDeserializer: {{ .Values.copy.source.connection.kafka.key_deserializer | quote }}
-      valueDeserializer: {{ .Values.copy.source.connection.kafka.value_deserializer | quote }}
-      {{ if .Values.copy.source.vault.read }}
+      sslTruststorePassword: {{ .source.connection.kafka.ssl_truststore_password | quote }}
+      securityProtocol: {{ .source.connection.kafka.security_protocol | quote }}
+      saslMechanism: {{ .source.connection.kafka.sasl_mechanism | quote }}
+      keyDeserializer: {{ .source.connection.kafka.key_deserializer | quote }}
+      valueDeserializer: {{ .source.connection.kafka.value_deserializer | quote }}
+      {{ if .source.vault.read }}
       vault:
-{{ toYaml .Values.copy.source.vault.read | indent 8 }}
+{{ toYaml .source.vault.read | indent 8 }}
       {{ end }}
   destination:
     s3:
-      endpoint: {{ .Values.copy.destination.connection.s3.endpoint | quote }}
-      bucket: {{ .Values.copy.destination.connection.s3.bucket | quote}}
-      objectKey: {{ .Values.copy.destination.connection.s3.object_key | quote }}
-      dataFormat: {{ .Values.copy.destination.format | quote}}
-      {{ if .Values.copy.destination.vault.write }}
+      endpoint: {{ .destination.connection.s3.endpoint | quote }}
+      bucket: {{ .destination.connection.s3.bucket | quote}}
+      objectKey: {{ .destination.connection.s3.object_key | quote }}
+      dataFormat: {{ .destination.format | quote}}
+      {{ if .destination.vault.write }}
       vault:
-{{ toYaml .Values.copy.destination.vault.write | indent 8 }}
+{{ toYaml .destination.vault.write | indent 8 }}
       {{ end }}
-  {{- if .Values.copy.transformations }}
+  {{- if .transformations }}
   transformation:
   {{- $redactColumns := list -}}
   {{- $removeColumns := list -}}
-  {{- range .Values.copy.transformations -}}
+  {{- range .transformations -}}
     {{- if eq .name "RedactAction" -}}
       {{- $redactColumns = .RedactAction.columns -}}
     {{- end -}}
@@ -66,6 +68,11 @@ spec:
         - {{ . }}
         {{- end }}
   {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- else }}
+  source:
+  destination:
   {{- end }}
   triggerInterval: "10 seconds"
   {{ if .Values.image }}

--- a/modules/fybrik-implicit-copy-stream/values.yaml
+++ b/modules/fybrik-implicit-copy-stream/values.yaml
@@ -9,9 +9,9 @@ image: "ghcr.io/fybrik/mover:0.5.0"
 imagePullPolicy: null
 noFinalizer: "true"
 
-copy:
+assets:
   # copies from source
-  source:
+- source:
     vault: {}
     connection:
       kafka: {}

--- a/modules/fybrik-implicit-copy-stream/values.yaml.sample
+++ b/modules/fybrik-implicit-copy-stream/values.yaml.sample
@@ -1,7 +1,7 @@
 image: localhost:5000/fybrik-system/dummy-mover:latest
 
-copy:
-  source:
+assets:
+- source:
     connection:
       kafka:
         bootstrap_servers: "broker1:9093"


### PR DESCRIPTION
This PR implements part of issue #56 
It replaces the "copy" with "assets" in the batchTranfer/StreamTransfer resources.

Handling the app-uuid will be done in a separate issue dedicated to improve logging.