### PR TITLE
Prepare for 0.7.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Version 0.5.0 of the data movement operator (DMO) is available in Fybrik 0.5.x.
 | Fybrik           | DMO
 | ---              | ---
 | 0.6.x            | 0.6.x
+| 0.7.x            | 0.7.x
 
 
 Installing the chart: (available from DMO version 0.6.1 and above)
@@ -52,12 +53,14 @@ CSM - copy stream module
 | ---              | ---     | ---     | ---
 | 0.5.x            | 0.5.x   | 0.5.x   | `https://github.com/fybrik/data-movement-operator/releases/download/v0.5.0/implicit-copy-batch-module.yaml`
 | 0.6.x            | 0.6.x   | 0.5.x   | `https://github.com/fybrik/data-movement-operator/releases/download/v0.6.0/implicit-copy-batch-module.yaml`
+| 0.7.x            | 0.7.x   | 0.5.x   | `https://github.com/fybrik/data-movement-operator/releases/download/v0.6.0/implicit-copy-batch-module.yaml`
 | master           | master  | master  | `https://raw.githubusercontent.com/fybrik/data-movement-operator/master/modules/implicit-copy-batch-module.yaml`
 
 | Fybrik           | CSM     | Mover   | Command
 | ---              | ---     | ---     | ---
 | 0.5.x            | 0.5.x   | 0.5.x   | `https://github.com/fybrik/data-movement-operator/releases/download/v0.5.0/implicit-copy-stream-module.yaml`
 | 0.6.x            | 0.6.x   | 0.5.x   | `https://github.com/fybrik/data-movement-operator/releases/download/v0.6.0/implicit-copy-stream-module.yaml`
+| 0.7.x            | 0.7.x   | 0.5.x   | `https://github.com/fybrik/data-movement-operator/releases/download/v0.7.0/implicit-copy-stream-module.yaml`
 | master           | master  | master  | `https://raw.githubusercontent.com/fybrik/data-movement-operator/master/modules/implicit-copy-stream-module.yaml`
 
 ## Development version using the repo

--- a/hack/test-script/Asset-0.7.0.yaml
+++ b/hack/test-script/Asset-0.7.0.yaml
@@ -1,0 +1,30 @@
+apiVersion: katalog.fybrik.io/v1alpha1
+kind: Asset
+metadata:
+  name: paysim-csv
+spec:
+  secretRef: 
+    name: paysim-csv
+  details:
+    dataFormat: csv
+    connection:
+      name: s3
+      s3:
+        endpoint: "http://localstack.fybrik-notebook-sample.svc.cluster.local:4566"
+        bucket: "demo"
+        object_key: "PS_20174392719_1491204439457_log.csv"
+  metadata:
+    name: Synthetic Financial Datasets For Fraud Detection
+    geography: theshire 
+    tags:
+      finance: true
+    columns:
+      - name: nameOrig
+        tags:
+          PII: true
+      - name: oldbalanceOrg
+        tags:
+          PII: true
+      - name: newbalanceOrig
+        tags:
+          PII: true

--- a/hack/test-script/flight-module-0.7.0.yaml
+++ b/hack/test-script/flight-module-0.7.0.yaml
@@ -1,0 +1,48 @@
+apiVersion: app.fybrik.io/v1alpha1
+kind: FybrikModule
+metadata:
+  name: arrow-flight-module
+  labels:
+    name: arrow-flight-module
+    version: latest # semantic version
+spec:
+  type: service
+  chart:
+    name: ghcr.io/fybrik/arrow-flight-module-chart:0.0.0-master
+    values:
+      image.tag: master
+  capabilities:
+    - capability: read
+      scope: workload
+      api:
+        connection:
+          name: fybrik-arrow-flight
+          fybrik-arrow-flight:
+            hostname: "{{ .Release.Name }}.{{ .Release.Namespace }}"
+            port: "80"
+            scheme: grpc
+      supportedInterfaces:
+        - source:
+            protocol: s3
+            dataformat: parquet
+        - source:
+            protocol: s3
+            dataformat: csv
+        - source:
+            protocol: fybrik-arrow-flight
+    - capability: write
+      scope: workload
+      api:
+        connection:
+          name: fybrik-arrow-flight
+          fybrik-arrow-flight:
+            hostname: "{{ .Release.Name }}.{{ .Release.Namespace }}"
+            port: "80"
+            scheme: grpc
+      supportedInterfaces:
+        - sink:
+            protocol: s3
+            dataformat: parquet
+        - sink:
+            protocol: s3
+            dataformat: csv

--- a/hack/test-script/fybrikStorage-0.7.0.yaml
+++ b/hack/test-script/fybrikStorage-0.7.0.yaml
@@ -1,0 +1,11 @@
+apiVersion:   app.fybrik.io/v1alpha1
+kind:         FybrikStorageAccount
+metadata:
+  name: storage-account
+  namespace: fybrik-system
+spec:
+  id: theshire-object-store
+  region: theshire
+  endpoint: "http://localstack.fybrik-notebook-sample.svc.cluster.local:4566"
+  secretRef:  bucket-creds
+

--- a/hack/test-script/fybrikapplication-0.7.0.yaml
+++ b/hack/test-script/fybrikapplication-0.7.0.yaml
@@ -1,0 +1,18 @@
+apiVersion: app.fybrik.io/v1alpha1
+kind: FybrikApplication
+metadata:
+  name: my-notebook
+  labels:
+    app: my-notebook
+spec:
+  selector:
+    workloadSelector:
+      matchLabels:
+        app: my-notebook
+  appInfo:
+    intent: Fraud Detection
+  data:
+    - dataSetID: "fybrik-notebook-sample/paysim-csv"
+      requirements:
+        interface: 
+          protocol: fybrik-arrow-flight

--- a/hack/test-script/sample-policy-0.7.0.rego
+++ b/hack/test-script/sample-policy-0.7.0.rego
@@ -1,0 +1,16 @@
+package dataapi.authz
+
+rule[{}] {
+  input.action.actionType == "write"
+  true
+}
+
+
+rule[{"action": {"name":"RedactAction", "columns": column_names}, "policy": description}] {
+  description := "Redact columns tagged as PII in datasets tagged with finance = true"
+  input.action.actionType == "read"
+  input.resource.metadata.tags.finance
+  column_names := [input.resource.metadata.columns[i].name | input.resource.metadata.columns[i].tags.PII]
+  count(column_names) > 0
+}
+


### PR DESCRIPTION
closes #62 
closes #59 

This PR contains the following changes to prepare for release 0.7.0
1. it updates the compatibility matrix in readme file 
2. it updates the resources which are used in the hack/test_module test to be compatible with Fybrik 0.7.0.